### PR TITLE
Add prerequisite wrap to camel-leveldb

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1026,6 +1026,7 @@
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/${xmlresolver-bundle-version}</bundle>
   </feature>
   <feature name='camel-leveldb' version='${project.version}' resolver='(obr)' start-level='50'>
+    <feature prerequisite="true">wrap</feature>
     <feature version='${project.version}'>camel-core</feature>
     <bundle dependency='true'>wrap:mvn:org.fusesource.leveldbjni/leveldbjni-all/${leveldbjni-version}$Bundle-Version=${leveldbjni-version}&amp;Export-Package=*;-noimport:=true;version="${leveldbjni-version}"</bundle>
     <bundle dependency='true'>mvn:org.fusesource.hawtbuf/hawtbuf/${hawtbuf-version}</bundle>


### PR DESCRIPTION
After migrating from ServiceMix 6 to 7.0.1 (which is using camel 2.16.5), when trying to update my integration tests I had some problems with loading camel-leveldb using pax exam.

When used:
```
features(maven().groupId("org.apache.camel.karaf").artifactId("apache-camel").type("xml").classifier("features").version("2.16.5"),
"camel-blueprint",
"camel-test",
[...]
"camel-leveldb
),
```
It simply couldn't load package `camel-leveldb`, because `WRAP` wasn't installed and running. Pax exam simply tried to load and install `camel-leveldb `before `WRAP.` This resulted in error:

`Caused by: java.net.MalformedURLException: Unknown protocol: wrap `

The solution to that is to create my own project with features.xml file, copy the camel-leveldb configuration from Camel's one and add:

`<feature prerequisite="true">wrap</feature>`

So why not add this line to the Camel itself? It should resolve problems in integration tests using pax exam.

What do you think? 